### PR TITLE
Feature: Show actual payment method

### DIFF
--- a/app/code/community/Op/Checkout/Block/Payment/Info.php
+++ b/app/code/community/Op/Checkout/Block/Payment/Info.php
@@ -2,8 +2,21 @@
 
 class Op_Checkout_Block_Payment_Info extends Mage_Payment_Block_Info
 {
-    const METHOD_TITLE = 'Op Payment Service';
-
+    const PAYMENT_METHOD_MAPPING = [
+      'osuuspankki1' => 'Osuuspankki',
+      'nordea2' => 'Nordea',
+      'handelsbanken3' => 'Handelsbanken',
+      'pop4' => 'POP Pankki',
+      'aktia5' => 'Aktia',
+      'saastopankki6' => 'Säästöpankki',
+      'omasp7' => 'OmaSP',
+      'spankki8' => 'S-Pankki',
+      'alandsbanken9' => 'Ålandsbanken',
+      'danske10' => 'Danske Bank',
+      'creditcard1' => 'Visa',
+      'creditcard2' => 'Visa Electron',
+      'creditcard3' => 'MasterCard',
+    ];
     protected function _construct()
     {
         parent::_construct();
@@ -15,8 +28,12 @@ class Op_Checkout_Block_Payment_Info extends Mage_Payment_Block_Info
         return Mage::getStoreConfig('payment/opcheckout/logo');
     }
 
-    public function getPaymentServiceTitle()
+    /**
+     * @return string
+     */
+    public function getPaymentMethod()
     {
-        return self::METHOD_TITLE;
+        $method = $this->getInfo()->getAdditionalInformation('opcheckout_payment_method');
+        return self::PAYMENT_METHOD_MAPPING[$method] ?? $this->__('Online payment');
     }
 }

--- a/app/code/community/Op/Checkout/etc/system.xml
+++ b/app/code/community/Op/Checkout/etc/system.xml
@@ -28,6 +28,14 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </skipbankselection>
+                        <title translate="label">
+                            <label>Title</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>11</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </title>
                         <merchant_id translate="label">
                             <label>Merchant Id</label>
                             <frontend_type>text</frontend_type>
@@ -43,7 +51,7 @@
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                         </auth_code>
                         <notifications translate="label">
                             <label>Notifications email</label>

--- a/app/design/frontend/base/default/template/opcheckout/info.phtml
+++ b/app/design/frontend/base/default/template/opcheckout/info.phtml
@@ -1,1 +1,2 @@
-<p><?=$this->getPaymentServiceTitle();?></p>
+<?php /** @var Op_Checkout_Block_Payment_Info $this */ ?>
+<?php echo $this->getPaymentMethod() ?>


### PR DESCRIPTION
This PR changes usage of how payment methods are shown:

- Show actual payment method title like "Osuuspankki" or "Visa" instead of ambiguous "Op Payment Service" which doesn't tell anything to user as fallback just show "Online payment"
- Add title as configurable field rather than showing ambiguous "Op Payment Service" in checkout as title which doesn't tell anything to user